### PR TITLE
Add flexibility to Discord User ID Length

### DIFF
--- a/src/CommunalMod.ts
+++ b/src/CommunalMod.ts
@@ -410,7 +410,7 @@ export class CommunalMod {
   }
 
   private async banCommand(message: Discord.Message) {
-    const idPattern = /\d{18}/g;
+    const idPattern = /\d{17,20}/g;
     const usernamePattern = /--username\s*/g;
     const reasonPattern = /--reason\s*.*/g;
 
@@ -506,7 +506,7 @@ export class CommunalMod {
   }
 
   private async unbanCommand(message: Discord.Message) {
-    const idPattern = /\d{18}/g;
+    const idPattern = /\d{17,20}/g;
     const reasonPattern = /--reason\s*.*/g;
 
     const ids = message.content.match(idPattern);
@@ -762,11 +762,11 @@ export class CommunalMod {
     }
 
     const banCommandPattern =
-      /\s*!ban (--username\s+)?(\d{18}\s*)+(--reason\s*.*)?/g;
+      /\s*!ban (--username\s+)?(\d{17,20}\s*)+(--reason\s*.*)?/g;
     const serverCommandPattern = /\s*!servers\s*/g;
-    const unbanCommandPattern = /\s*!unban (\d{18}\s*)+/g;
+    const unbanCommandPattern = /\s*!unban (\d{17,20}\s*)+/g;
     const raidCommandPattern =
-      /\s*!raid\s+--user\s+(\d{18})\s+--before\s+(\d+)\s+--after\s+(\d+)\s*/;
+      /\s*!raid\s+--user\s+(\d{17,20})\s+--before\s+(\d+)\s+--after\s+(\d+)\s*/;
 
     if (banCommandPattern.test(msgContent)) {
       this.banCommand(message);

--- a/src/TanssiCommunalMod.ts
+++ b/src/TanssiCommunalMod.ts
@@ -274,7 +274,7 @@ export class TanssiCommunalMod {
   }
 
   private async banCommand(message: Discord.Message) {
-    const idPattern = /\d{18}/g;
+    const idPattern = /\d{17,20}/g;
     const usernamePattern = /--username\s*/g;
     const reasonPattern = /--reason\s*.*/g;
 
@@ -370,7 +370,7 @@ export class TanssiCommunalMod {
   }
 
   private async unbanCommand(message: Discord.Message) {
-    const idPattern = /\d{18}/g;
+    const idPattern = /\d{17,20}/g;
     const reasonPattern = /--reason\s*.*/g;
 
     const ids = message.content.match(idPattern);
@@ -626,11 +626,11 @@ export class TanssiCommunalMod {
     }
 
     const banCommandPattern =
-      /\s*!ban (--username\s+)?(\d{18}\s*)+(--reason\s*.*)?/g;
+      /\s*!ban (--username\s+)?(\d{17,20}\s*)+(--reason\s*.*)?/g;
     const serverCommandPattern = /\s*!servers\s*/g;
-    const unbanCommandPattern = /\s*!unban (\d{18}\s*)+/g;
+    const unbanCommandPattern = /\s*!unban (\d{17,20}\s*)+/g;
     const raidCommandPattern =
-      /\s*!raid\s+--user\s+(\d{18})\s+--before\s+(\d+)\s+--after\s+(\d+)\s*/;
+      /\s*!raid\s+--user\s+(\d{17,20})\s+--before\s+(\d+)\s+--after\s+(\d+)\s*/;
 
     if (banCommandPattern.test(msgContent)) {
       this.banCommand(message);


### PR DESCRIPTION
There was a user with an ID of length 19 that was causing issues.

This PR Adds a bit of flexibility, so that the ID can be between 17 and 20 characters long